### PR TITLE
CC-3693: Removed hidden dependency to symfony/twig-bridge (Backport for 3.22.0)

### DIFF
--- a/src/Spryker/Zed/Gui/Presentation/Form/Type/form_extension.twig
+++ b/src/Spryker/Zed/Gui/Presentation/Form/Type/form_extension.twig
@@ -13,12 +13,12 @@
 
 {% block form_errors -%}
     {% if errors|length > 0 -%}
-        {% if form is not rootform %}<span class="help-block">{% else %}<div class="alert alert-danger">{% endif %}
+        {% if form.parent is not null %}<span class="help-block">{% else %}<div class="alert alert-danger">{% endif %}
         <ul class="list-unstyled">
         {%- for error in errors -%}
             <li><span class="glyphicon glyphicon-exclamation-sign"></span> {{ error.message | trans }}</li>
         {%- endfor -%}
     </ul>
-        {% if form is not rootform %}</span>{% else %}</div>{% endif %}
+        {% if form.parent is not null %}</span>{% else %}</div>{% endif %}
     {%- endif %}
 {%- endblock form_errors %}


### PR DESCRIPTION
- Developer(s): @ostrizhny

- Ticket: https://spryker.atlassian.net/browse/CC-3693

- Academy PR: -

- Release Group: URL_HERE

Version: 3.22.1

#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Gui                   | patch                 |                       |

#### Release Notes

Removed hidden dependency.

-----------------------------------------

#### Module Gui

##### Change log

Bugfixes

* Removed hidden dependency in `Spryker/Zed/Gui/Presentation/Form/Type/form_extension.twig` by avoiding of using of Twig test funciton: `rootform`.

