### PR TITLE
Consistent Scrolling for Data Table Headers and Body

### DIFF
--- a/assets/Zed/js/modules/libs/data-table.js
+++ b/assets/Zed/js/modules/libs/data-table.js
@@ -22,7 +22,7 @@ if (translationObj.sSearch) {
 
 var defaultConfiguration = {
     scrollX: 'auto',
-    autoWidth: false,
+    autoWidth: true,
     language: translationObj,
     dom:
         "<'row'<'col-sm-12 col-md-6'i><'col-sm-12 col-md-6'f>>" +
@@ -34,7 +34,7 @@ var noSearchConfiguration = {
     bFilter: false,
     bInfo: false,
     scrollX: 'auto',
-    autoWidth: false,
+    autoWidth: true,
 };
 
 function setTableErrorMode(errorMode) {

--- a/assets/Zed/sass/_data-tables.scss
+++ b/assets/Zed/sass/_data-tables.scss
@@ -3,8 +3,6 @@ $data-table-selected-row-border-size: 1px;
 $data-table-selected-row-border-color: rgba(#0088cc, 1);
 
 .dataTables_scrollHeadInner {
-    width: 100% !important;
-
     & > .table {
         width: 100% !important;
     }


### PR DESCRIPTION
## PR Description

Currently, the column headers of data tables may scroll independently of the respective column body when the table width exceeds the screen size. Due to this, column header and body may become misaligned, which can make it hard to decipher which column a table cell datum is referring to. The changes proposed in this PR ought to fix this issue, making the column headers scroll consistently with the respective column body.

#### Limitations
The proposed fix disables horizontal table stretch when the table's width is less than the available horizontal space in the surrounding container.

### Example
#### Before the Changes
![image](https://user-images.githubusercontent.com/16663164/174260114-61b05962-e600-4a82-ba2d-9d9aaa1840ee.png)

#### After the Changes
![image](https://user-images.githubusercontent.com/16663164/174260641-6bbb98b1-ddba-453a-bddc-ba84c26e6858.png)

## Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
