### PR TITLE
Update tabs.js so tabHeader will show error indicator again

### DIFF
--- a/assets/Zed/js/modules/libs/tabs.js
+++ b/assets/Zed/js/modules/libs/tabs.js
@@ -28,7 +28,6 @@ Tabs.prototype.checkErrors = function () {
         } else {
             var tabHeader = self.tabsContainer.find('.nav-tabs li[data-tab-content-id="' + tab.id + '"]');
         }
-        var tabHeader = self.tabsContainer.find('.nav-tabs li[data-bs-target="' + tab.id + '"]');
 
         if (hasError) {
             tabHeader.addClass('error');

--- a/contribution-license-agreement.txt
+++ b/contribution-license-agreement.txt
@@ -1,0 +1,1 @@
+I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/gui/blob/ecd0a59/CONTRIBUTING.md.


### PR DESCRIPTION
spryker-gui: tabHeader not showing error indicator when not using latest bootstrap in backoffice

## PR Description
When a required input field in backoffice isn't set (e.g. in product management when editing an abstract product and the large image url for an image isn't set) there should be error indicated in the corresponding tab header (red background for the header). No error indication is shown.

Before the fix: 
<img width="1719" alt="before" src="https://github.com/user-attachments/assets/ffd139b0-1c77-4b8b-a9eb-687b50abace9" />
After the fix:
<img width="1719" alt="fixed" src="https://github.com/user-attachments/assets/ffffd183-f042-4620-9308-ba417a4dec5d" />


## Steps before you submit a PR
- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
`I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/gui/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
