### PR TITLE
Add missing class in ButtonGroupUrlGenerator

### DIFF
--- a/src/Spryker/Zed/Gui/Communication/Plugin/Twig/Buttons/ButtonGroupUrlGenerator.php
+++ b/src/Spryker/Zed/Gui/Communication/Plugin/Twig/Buttons/ButtonGroupUrlGenerator.php
@@ -82,7 +82,7 @@ class ButtonGroupUrlGenerator implements UrlGeneratorInterface
      */
     protected function generateAnchor($url)
     {
-        return '<li><a href="' . $url . '">';
+        return '<li><a href="' . $url . '" class="dropdown-item">';
     }
 
     /**


### PR DESCRIPTION
## PR Description
Add missing bootstrap5 Dropdown class in ButtonGroupUrlGenerator:
https://getbootstrap.com/docs/5.2/components/dropdowns/#single-button

[contribution-license-agreement.txt](https://github.com/user-attachments/files/27045165/contribution-license-agreement.txt)

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
